### PR TITLE
fix(deps): pin SQLitePCLRaw.lib.e_sqlite3 to 2.1.12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="NetEvolve.Extensions.TUnit" Version="3.5.348" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="TUnit" Version="1.48.0" />
     <PackageVersion Include="Verify.TUnit" Version="31.19.0" />
   </ItemGroup>


### PR DESCRIPTION
Resolves NU1903 (GHSA-2m69-gcr7-jv3q) transitively pulled in via Microsoft.Data.Sqlite. Same fix as dailydevops/healthchecks#1912.