### PR TITLE
chore: Migrate NSubstitute to TUnit.Mocks in Tests.Unit

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <PackageVersion Include="TUnit" Version="1.62.0" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.62.0" />
     <PackageVersion Include="Verify.TUnit" Version="31.27.0" />
   </ItemGroup>
 </Project>

--- a/tests/NetEvolve.Extensions.Data.Tests.PublicApi/NetEvolve.Extensions.Data.Tests.PublicApi.csproj
+++ b/tests/NetEvolve.Extensions.Data.Tests.PublicApi/NetEvolve.Extensions.Data.Tests.PublicApi.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="PublicApiGenerator" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
-    <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="Verify.TUnit" />
   </ItemGroup>

--- a/tests/NetEvolve.Extensions.Data.Tests.Unit/GlobalUsings.cs
+++ b/tests/NetEvolve.Extensions.Data.Tests.Unit/GlobalUsings.cs
@@ -1,4 +1,3 @@
-﻿global using NSubstitute.ExceptionExtensions;
-global using TUnit.Assertions;
+﻿global using TUnit.Assertions;
 global using TUnit.Assertions.Extensions;
 global using TUnit.Core;

--- a/tests/NetEvolve.Extensions.Data.Tests.Unit/IDataReaderExtensionsTests.cs
+++ b/tests/NetEvolve.Extensions.Data.Tests.Unit/IDataReaderExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NetEvolve.Extensions.Data.Tests.Unit;
 
 using System.Data;
-using NSubstitute;
 
 public class IDataReaderExtensionsTests
 {
@@ -20,7 +19,7 @@ public class IDataReaderExtensionsTests
     public void HasColumn_WhenNameIsNull_ThrowsArgumentNullException()
     {
         // Arrange
-        var reader = Substitute.For<IDataReader>();
+        var reader = IDataReader.Mock();
         string name = null!;
 
         // Act
@@ -31,7 +30,7 @@ public class IDataReaderExtensionsTests
     public void HasColumn_WhenNameIsEmpty_ThrowsArgumentNullException()
     {
         // Arrange
-        var reader = Substitute.For<IDataReader>();
+        var reader = IDataReader.Mock();
         var name = string.Empty;
 
         // Act
@@ -43,12 +42,12 @@ public class IDataReaderExtensionsTests
     public async Task HasColumn_Theory_Expected(bool expected, string name)
     {
         // Arrange
-        var reader = Substitute.For<IDataReader>();
+        var reader = IDataReader.Mock();
 
         _ = reader.FieldCount.Returns(2);
 
-        _ = reader.GetName(Arg.Is(0)).Returns("Id");
-        _ = reader.GetName(Arg.Is(1)).Returns("Name");
+        _ = reader.GetName(0).Returns("Id");
+        _ = reader.GetName(1).Returns("Name");
 
         // Act
         var result = reader.HasColumn(name);

--- a/tests/NetEvolve.Extensions.Data.Tests.Unit/IDataRecordExtensionsTests.cs
+++ b/tests/NetEvolve.Extensions.Data.Tests.Unit/IDataRecordExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEvolve.Extensions.Data.Tests.Unit;
 
 using System.Data;
-using NSubstitute;
+using System.Diagnostics.CodeAnalysis;
 
 public class IDataRecordExtensionsTests
 {
@@ -1468,57 +1468,62 @@ public class IDataRecordExtensionsTests
 
     private static readonly Guid _guidMax = Guid.NewGuid();
 
+    [SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "Return type must stay IDataRecord to keep the mock's setup separate from the record used by callers."
+    )]
     private static IDataRecord CreateTestRecord()
     {
-        var record = Substitute.For<IDataRecord>();
+        var record = IDataRecord.Mock();
 
-        _ = record.GetOrdinal(Arg.Any<string>()).Returns(-1);
-        _ = record.GetOrdinal(Arg.Is("Id")).Returns(0);
-        _ = record.GetOrdinal(Arg.Is("Name")).Returns(1);
-        _ = record.GetOrdinal(Arg.Is("IsActive")).Returns(2);
+        _ = record.GetOrdinal(Any<string>()).Returns(-1);
+        _ = record.GetOrdinal("Id").Returns(0);
+        _ = record.GetOrdinal("Name").Returns(1);
+        _ = record.GetOrdinal("IsActive").Returns(2);
 
-        _ = record.IsDBNull(Arg.Any<int>()).Returns(false);
-        _ = record.IsDBNull(Arg.Is<int>(i => i < 0)).Throws<IndexOutOfRangeException>();
-        _ = record.IsDBNull(Arg.Is(0)).Returns(true);
+        _ = record.IsDBNull(Any<int>()).Returns(false);
+        _ = record.IsDBNull(i => i < 0).Throws<IndexOutOfRangeException>();
+        _ = record.IsDBNull(0).Returns(true);
 
-        _ = record.GetBoolean(Arg.Any<int>()).Returns(false);
-        _ = record.GetBoolean(Arg.Is(1)).Returns(true);
+        _ = record.GetBoolean(Any<int>()).Returns(false);
+        _ = record.GetBoolean(1).Returns(true);
 
-        _ = record.GetByte(Arg.Any<int>()).Returns<byte>(0x00b);
-        _ = record.GetByte(Arg.Is(1)).Returns<byte>(0x01b);
+        _ = record.GetByte(Any<int>()).Returns(0x00b);
+        _ = record.GetByte(1).Returns(0x01b);
 
-        _ = record.GetChar(Arg.Any<int>()).Returns(' ');
-        _ = record.GetChar(Arg.Is(1)).Returns('\t');
+        _ = record.GetChar(Any<int>()).Returns(' ');
+        _ = record.GetChar(1).Returns('\t');
 
-        _ = record.GetDateTime(Arg.Any<int>()).Returns(DateTime.MinValue);
-        _ = record.GetDateTime(Arg.Is(1)).Returns(DateTime.FromOADate(0));
+        _ = record.GetDateTime(Any<int>()).Returns(DateTime.MinValue);
+        _ = record.GetDateTime(1).Returns(DateTime.FromOADate(0));
 
-        _ = record.GetDecimal(Arg.Any<int>()).Returns(decimal.MinValue);
-        _ = record.GetDecimal(Arg.Is(1)).Returns(decimal.MaxValue);
+        _ = record.GetDecimal(Any<int>()).Returns(decimal.MinValue);
+        _ = record.GetDecimal(1).Returns(decimal.MaxValue);
 
-        _ = record.GetDouble(Arg.Any<int>()).Returns(double.MinValue);
-        _ = record.GetDouble(Arg.Is(1)).Returns(double.MaxValue);
+        _ = record.GetDouble(Any<int>()).Returns(double.MinValue);
+        _ = record.GetDouble(1).Returns(double.MaxValue);
 
-        _ = record.GetFloat(Arg.Any<int>()).Returns(float.MinValue);
-        _ = record.GetFloat(Arg.Is(1)).Returns(float.MaxValue);
+        _ = record.GetFloat(Any<int>()).Returns(float.MinValue);
+        _ = record.GetFloat(1).Returns(float.MaxValue);
 
-        _ = record.GetGuid(Arg.Any<int>()).Returns(Guid.Empty);
-        _ = record.GetGuid(Arg.Is(1)).Returns(_guidMax);
+        _ = record.GetGuid(Any<int>()).Returns(Guid.Empty);
+        _ = record.GetGuid(1).Returns(_guidMax);
 
-        _ = record.GetInt16(Arg.Any<int>()).Returns(short.MinValue);
-        _ = record.GetInt16(Arg.Is(1)).Returns(short.MaxValue);
+        _ = record.GetInt16(Any<int>()).Returns(short.MinValue);
+        _ = record.GetInt16(1).Returns(short.MaxValue);
 
-        _ = record.GetInt32(Arg.Any<int>()).Returns(int.MinValue);
-        _ = record.GetInt32(Arg.Is(1)).Returns(int.MaxValue);
+        _ = record.GetInt32(Any<int>()).Returns(int.MinValue);
+        _ = record.GetInt32(1).Returns(int.MaxValue);
 
-        _ = record.GetInt64(Arg.Any<int>()).Returns(long.MinValue);
-        _ = record.GetInt64(Arg.Is(1)).Returns(long.MaxValue);
+        _ = record.GetInt64(Any<int>()).Returns(long.MinValue);
+        _ = record.GetInt64(1).Returns(long.MaxValue);
 
-        _ = record.GetString(Arg.Any<int>()).Returns(string.Empty);
-        _ = record.GetString(Arg.Is(1)).Returns("Hello World!");
+        _ = record.GetString(Any<int>()).Returns(string.Empty);
+        _ = record.GetString(1).Returns("Hello World!");
 
-        _ = record.GetValue(Arg.Any<int>()).Returns(string.Empty);
-        _ = record.GetValue(Arg.Is(1)).Returns("Hello World!");
+        _ = record.GetValue(Any<int>()).Returns(string.Empty);
+        _ = record.GetValue(1).Returns("Hello World!");
 
         return record;
     }

--- a/tests/NetEvolve.Extensions.Data.Tests.Unit/NetEvolve.Extensions.Data.Tests.Unit.csproj
+++ b/tests/NetEvolve.Extensions.Data.Tests.Unit/NetEvolve.Extensions.Data.Tests.Unit.csproj
@@ -7,8 +7,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
+    <!--
+      NSubstitute is retained solely for DbDataReaderExtensionsTests.cs: TUnit.Mocks 1.62.0's
+      source generator emits "Cannot call an abstract base member" (CS0205) for
+      DbDataReader.this[int]/this[string] when generating a mock for the abstract DbDataReader
+      class, because those indexers are abstract with no base implementation to forward to.
+      Remove once TUnit.Mocks fixes generating mocks for abstract classes with abstract indexers.
+    -->
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.Mocks" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NetEvolve.Extensions.Data\NetEvolve.Extensions.Data.csproj" />

--- a/tests/NetEvolve.Extensions.Data.Tests.Unit/NetEvolve.Extensions.Data.Tests.Unit.csproj
+++ b/tests/NetEvolve.Extensions.Data.Tests.Unit/NetEvolve.Extensions.Data.Tests.Unit.csproj
@@ -13,6 +13,7 @@
       DbDataReader.this[int]/this[string] when generating a mock for the abstract DbDataReader
       class, because those indexers are abstract with no base implementation to forward to.
       Remove once TUnit.Mocks fixes generating mocks for abstract classes with abstract indexers.
+      https://github.com/thomhurst/TUnit/issues/6516
     -->
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />


### PR DESCRIPTION
## Summary

- Migrates `IDataReaderExtensionsTests.cs` and `IDataRecordExtensionsTests.cs` in `NetEvolve.Extensions.Data.Tests.Unit` from NSubstitute to [TUnit.Mocks](https://tunit.dev/docs/writing-tests/mocking/), consolidating onto the TUnit ecosystem already used as this project's test framework.
- Closes #555.

## Scoped exception

`DbDataReaderExtensionsTests.cs` stays on NSubstitute. TUnit.Mocks 1.62.0 (currently the latest) generates a mock implementation for `DbDataReader` that fails to compile:

```
error CS0205: Cannot call an abstract base member: 'DbDataReader.this[int]'
error CS0205: Cannot call an abstract base member: 'DbDataReader.this[string]'
```

`DbDataReader`'s indexers are abstract with no base implementation, so the generator's strategy of forwarding to `base[...]` doesn't compile. This is a source-generator limitation, not something fixable from test code — confirmed with a minimal, standalone repro, filed upstream as [thomhurst/TUnit#6516](https://github.com/thomhurst/TUnit/issues/6516). The `NSubstitute` package reference and comment in the csproj document this as a scoped, removable exception (linking that issue), mirroring the approach taken for similar generator limitations in [dailydevops/healthchecks#2049](https://github.com/dailydevops/healthchecks/issues/2049) / [#2051](https://github.com/dailydevops/healthchecks/pull/2051).

Also removes the unused `NSubstitute` package reference from `NetEvolve.Extensions.Data.Tests.PublicApi.csproj` (dead reference, no file in that project used it).

## Test plan

- [x] `dotnet build` (whole solution, all TFMs) — 0 warnings, 0 errors
- [x] `dotnet test` for `NetEvolve.Extensions.Data.Tests.Unit` across net8.0/net9.0/net10.0 — 921/921 passed
- [x] Verified the migrated `IDataRecordExtensionsTests.CreateTestRecord()` helper's overlapping matcher setups (`Any<int>()` general fallback + exact-value/predicate overrides) preserve NSubstitute's "later matching setup wins" semantics — all edge-case theory tests (index 0, 1, negative) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)