### PR TITLE
test: add ordinal-comparison regression tests for HasColumn

### DIFF
--- a/tests/NetEvolve.Extensions.Data.Tests.Unit/IDataReaderExtensionsTests.cs
+++ b/tests/NetEvolve.Extensions.Data.Tests.Unit/IDataReaderExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NetEvolve.Extensions.Data.Tests.Unit;
 
 using System.Data;
+using global::TUnit.Core.Executors;
 
 public class IDataReaderExtensionsTests
 {
@@ -57,4 +58,51 @@ public class IDataReaderExtensionsTests
     }
 
     public static IEnumerable<(bool, string)> HasColumnData => [(true, "Id"), (true, "namE"), (false, "Mail")];
+
+    /// <summary>
+    /// Under the Turkish culture, "i" and "I" do not fold to each other the way they do everywhere
+    /// else - the dotted/dotless "I" problem - so a comparison that quietly used the current or
+    /// invariant culture instead of <see cref="StringComparison.OrdinalIgnoreCase"/> would answer this
+    /// differently depending on the thread's culture. <c>HasColumn</c> must not.
+    /// </summary>
+    [Test]
+    [Culture("tr-TR")]
+    public async Task HasColumn_UnderTurkishCulture_StillComparesOrdinally()
+    {
+        // Arrange
+        var reader = IDataReader.Mock();
+
+        _ = reader.FieldCount.Returns(1);
+        _ = reader.GetName(0).Returns("ID");
+
+        // Act
+        var result = reader.HasColumn("id");
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    /// <summary>
+    /// The Unicode Roman numeral "Ⅰ" (U+2160) carries a compatibility decomposition to the plain
+    /// letter "I", which the linguistic comparers behind <see cref="StringComparison.CurrentCultureIgnoreCase"/>
+    /// and <see cref="StringComparison.InvariantCultureIgnoreCase"/> fold on - so they treat "Ⅰ" and
+    /// "I" as the same letter regardless of thread culture. <see cref="StringComparison.Ordinal"/>
+    /// compares raw code points and never applies that folding, so <c>HasColumn</c> must not confuse a
+    /// column named "I" with a lookup for "Ⅰ".
+    /// </summary>
+    [Test]
+    public async Task HasColumn_NameIsAUnicodeRomanNumeral_DoesNotMatchThePlainLetterColumn()
+    {
+        // Arrange
+        var reader = IDataReader.Mock();
+
+        _ = reader.FieldCount.Returns(1);
+        _ = reader.GetName(0).Returns("I");
+
+        // Act
+        var result = reader.HasColumn("Ⅰ");
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- `HasColumn` compares column names with `StringComparison.OrdinalIgnoreCase`. This adds two regression tests pinning that choice against culture-aware alternatives that would silently disagree with it:
  - `HasColumn_UnderTurkishCulture_StillComparesOrdinally` - under the Turkish culture, `i`/`I` do not fold the way they do everywhere else (the dotted/dotless I problem), so a comparison that quietly used the current culture instead of ordinal would answer differently depending on the thread's culture.
  - `HasColumn_NameIsAUnicodeRomanNumeral_DoesNotMatchThePlainLetterColumn` - the Unicode Roman numeral `Ⅰ` (U+2160) has a compatibility decomposition to the plain letter `I`, which linguistic (current/invariant culture) comparers fold on regardless of thread culture, while ordinal comparison correctly treats them as different code points.

## Test plan
- [x] `dotnet test tests/NetEvolve.Extensions.Data.Tests.Unit` passes locally (309/309)